### PR TITLE
Changes to support ppc64le architecture

### DIFF
--- a/systest/Cargo.toml
+++ b/systest/Cargo.toml
@@ -6,7 +6,7 @@ build = "build.rs"
 
 [dependencies]
 jemalloc-sys = { path = "../jemalloc-sys" }
-libc = "0.1"
+libc = "0.2"
 
 [build-dependencies]
 ctest = { git = "https://github.com/alexcrichton/ctest" }


### PR DESCRIPTION
Updating libc version as the 0.1 is not supported on ppc64le

This change is already merged here:
https://github.com/alexcrichton/jemallocator/commit/0003dce9bdf8b32dc255c1f720aa1a084f9ca734

and was submitted as part of the following PR
https://github.com/alexcrichton/jemallocator/pull/13